### PR TITLE
Mirror of python cpython#22555

### DIFF
--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -286,10 +286,11 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
         completed. The second set, named 'not_done', contains uncompleted
         futures.
     """
+    fs = set(fs)
     with _AcquireFutures(fs):
         done = set(f for f in fs
                    if f._state in [CANCELLED_AND_NOTIFIED, FINISHED])
-        not_done = set(fs) - done
+        not_done = fs - done
 
         if (return_when == FIRST_COMPLETED) and done:
             return DoneAndNotDoneFutures(done, not_done)
@@ -309,7 +310,7 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
             f._waiters.remove(waiter)
 
     done.update(waiter.finished_futures)
-    return DoneAndNotDoneFutures(done, set(fs) - done)
+    return DoneAndNotDoneFutures(done, fs - done)
 
 class Future(object):
     """Represents the result of an asynchronous computation."""


### PR DESCRIPTION
Mirror of python cpython#22555
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
concurrent.futures.wait was calling `len()` on possible iterables and we were converting the argument to set anyways. so just changed it to set from start.
checkout this [issue41938](https://bugs.python.org/issue41938) for more details.

<!-- issue-number: [bpo-41938](https://bugs.python.org/issue41938) -->
https://bugs.python.org/issue41938
<!-- /issue-number -->

